### PR TITLE
HP config default settings.

### DIFF
--- a/src/hp_manager.cpp
+++ b/src/hp_manager.cpp
@@ -337,7 +337,7 @@ namespace hp
         const std::string contract_id = crypto::generate_uuid();
         const std::string pubkey_hex = util::to_hex(pubkey);
 
-        // Defaults
+        // Default hp.cfg configs.
         d["node"]["history_config"]["max_primary_shards"] = 2;
         d["node"]["history_config"]["max_raw_shards"] = 2;
         d["hpfs"]["log"]["log_level"] = "err";


### PR DESCRIPTION
max_primary_shards: 2
max_raw_shards: 2
hpfs loglevel: err
log_level: inf
max_mbytes_per_file: 5
max_file_count: 10

Added above default hp.cfg values when creating a new HP instance.