### PR TITLE
Adding Dependency of bind9-host

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -77,7 +77,8 @@ sudo apt-get install -y \
     sqlite3 libsqlite3-dev \
     libboost-stacktrace-dev \
     fuse3 \
-    jq
+    jq \
+    bind9-host
 
 sudo cp $scriptdir/dependencies/libblake3.so /usr/local/lib/
 

--- a/installer/prereq.sh
+++ b/installer/prereq.sh
@@ -27,7 +27,7 @@ stage "Installing dependencies"
 # Added --allow-releaseinfo-change
 # To fix - Repository 'https://apprepo.vultr.com/ubuntu universal InRelease' changed its 'Codename' value from 'buster' to 'universal'
 apt-get update --allow-releaseinfo-change
-apt-get install -y uidmap slirp4netns fuse3 cgroup-tools quota curl openssl jq
+apt-get install -y uidmap slirp4netns fuse3 cgroup-tools quota curl openssl jq bind9-host
 # uidmap        # Required for rootless docker.
 # slirp4netns   # Required for high performance rootless networking.
 # fuse3         # Required for hpfs.
@@ -36,6 +36,7 @@ apt-get install -y uidmap slirp4netns fuse3 cgroup-tools quota curl openssl jq
 # curl          # Required to download installation artifacts.
 # openssl       # Required by Sashimono agent to create contract tls certs.
 # jq            # Used for json config file manipulation.
+# bind9-host    # Used for access DNS lookup utility.
 
 # Install nodejs if not exists.
 if ! command -v node &>/dev/null; then


### PR DESCRIPTION
- As in some Ubuntu editions `bind9-host` utility is not installed by default.